### PR TITLE
Fix some bugs on the login page

### DIFF
--- a/crates/web/src/components/login_form.rs
+++ b/crates/web/src/components/login_form.rs
@@ -64,7 +64,7 @@ pub fn login_form() -> Html {
                         oninput={on_username_input}
                       />
                       <input
-                        type="text"
+                        type="password"
                         id="password"
                         class="form-control my-4 py-2"
                         placeholder="Password"
@@ -73,7 +73,12 @@ pub fn login_form() -> Html {
                       />
                       <div class="text-center mt-3">
                         <button type="submit" class="btn btn-primary">{"Login"}</button>
-                        <a href="#" class="nav-link">{"Forgot password?"}</a>
+                      </div>
+                      <div class="text-center mt-3">
+                        <a href="#" class="nav-link p-0 d-inline-block">{"Forgot password?"}</a>
+                      </div>
+                      <div class="text-center mt-3">
+                        <a href="#" class="nav-link p-0 d-inline-block">{"Not a user?"}</a>
                       </div>
                     </form>
                   </div>


### PR DESCRIPTION
## What?
Fix some bugs on the login page

## Why?
We have three issues right now:

1) Password is using a plain textbox
2) The "forgot password?" div is stretched so the blank space is focusable
3) This is not an issue, but we should add the sign up link.

## How?
Use a password input type, and style the "forgot password?" and "not a user?" links to be inline-block.

## Testing
- [x] Used `trunk serve` to verify

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/74646696-7dca-4c04-8361-fc08a04c2088)

After:
![image](https://github.com/user-attachments/assets/7f6b1cdf-ecce-489a-a69b-e00ca7ae7fca)